### PR TITLE
Initial commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  install_aarch64:
+    runs-on: ubuntu-latest
+    name: Install on ${{ matrix.distro }} ${{ matrix.arch }}
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            distro: ubuntu_latest
+          - arch: aarch64
+            distro: alpine_latest
+          - arch: aarch64
+            distro: fedora_latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: uraimo/run-on-arch-action@v2
+        name: Install binary
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+
+          install: |
+            case "${{ matrix.distro }}" in
+              ubuntu*|jessie|stretch|buster|bullseye)
+                apt-get update -q -y
+                apt-get install -q -y wget sudo bash
+                ;;
+              fedora*)
+                dnf -y update
+                dnf -y install wget sudo bash
+                ;;
+              alpine*)
+                apk update
+                apk add wget sudo bash
+                ;;
+            esac
+
+          # Mount the root directory as /artifacts in the container
+          dockerRunArgs: |
+            --volume "${PWD}:/artifacts"
+
+          run: |
+            bash /artifacts/bor.sh
+            bash /artifacts/bor.sh 0.2.14
+            bash /artifacts/heimdall.sh
+            bash /artifacts/heimdall.sh 0.2.9
+
+  install_amd64:
+    runs-on: ${{ matrix.os }}
+    name: Install on ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install binary
+        run: |
+          ./bor.sh
+          ./bor.sh 0.2.14
+          ./heimdall.sh
+          ./heimdall.sh 0.2.9

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+## Installation scripts
+
+Utility scripts that install binaries based on the operating system. The script will ask the user for root permission as required by installation.
+
+### Setup
+
+Clone this git repository
+
+```
+git clone https://github.com/maticnetwork/install.git
+cd install
+```
+
+### Bor
+
+#### Install default bor binary
+
+```
+./bor.sh
+```
+
+#### Install a specific bor version
+
+Simply pass the version tag as the first argument to the installation script. Notice that the script will overwrite existing bor binaries if they exist. Example:
+
+```
+./bor.sh 0.2.14
+```
+
+
+### Heimdall
+
+#### Install default Heimdall binary
+
+```
+./heimdall.sh
+```
+
+#### Install a specific Heimdall version
+
+Simply pass the version tag as the first argument to the installation script. Notice that the script will overwrite existing Heimdall binaries if they exist. Example:
+
+```
+./heimdall.sh 0.2.19
+```

--- a/bor.sh
+++ b/bor.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+{ # Prevent execution if this script was only partially downloaded
+
+oops() {
+    echo "$0:" "$@" >&2
+    exit 1
+}
+
+umask 0022
+
+tmpDir="$(mktemp -d -t bor-temp-dir-XXXXXXXXXXX || \
+          oops "Can't create temporary directory for downloading files")"
+cleanup() {
+    rm -rf "$tmpDir"
+}
+trap cleanup EXIT INT QUIT TERM
+
+require_util() {
+    command -v "$1" > /dev/null 2>&1 ||
+        oops "you do not have '$1' installed, which I need to $2"
+}
+
+version="0.2.14"
+
+if [ ! -z "$1" ]; then
+    version="$1"
+    if [ "${version:0:1}" = "v" ]; then
+        version=${version:1}
+    fi
+fi
+
+baseUrl="https://github.com/maticnetwork/bor/releases/download/v${version}"
+
+echo $baseUrl
+
+case "$(uname -s).$(uname -m)" in
+    Linux.x86_64)
+        if command -v dpkg &> /dev/null; then
+            type="deb"
+            binary="bor_${version}_linux_amd64.deb"
+        elif command -v rpm &> /dev/null; then
+            type="rpm"
+            binary="bor_${version}_linux_x86_64.rpm"
+        elif command -v apk &> /dev/null; then
+            type="apk"
+            binary="bor_${version}_linux_amd64.apk"
+        else
+            type="tar.gz"
+            binary="bor_${version}_linux_amd64.tar.gz"
+        fi
+        ;;
+    Linux.aarch64)
+        if command -v dpkg &> /dev/null; then
+            type="deb"
+            binary="bor_${version}_linux_arm64.deb"
+        elif command -v rpm &> /dev/null; then
+            type="rpm"
+            binary="bor_${version}_linux_arm64.rpm"
+        elif command -v apk &> /dev/null; then
+            type="apk"
+            binary="bor_${version}_linux_arm64.apk"
+        else
+            type="tar.gz"
+            binary="bor_${version}_linux_arm64.tar.gz"
+        fi
+        ;;
+    Darwin.x86_64)
+        type="tar.gz"
+        binary="bor_${version}_darwin_amd64.tar.gz"
+        ;;
+    Darwin.arm64|Darwin.aarch64)
+        type="tar.gz"
+        binary="bor_${version}_darwin_arm64.tar.gz"
+        ;;
+    *) oops "sorry, there is no binary distribution for your platform";;
+esac
+
+url="${baseUrl}/${binary}"
+
+package=$tmpDir/$binary
+
+if command -v curl > /dev/null 2>&1; then
+    fetch() { curl -L "$1" -o "$2"; }
+elif command -v wget > /dev/null 2>&1; then
+    fetch() { wget "$1" -O "$2"; }
+else
+    oops "you don't have wget or curl installed, which I need to download the binary package"
+fi
+
+echo "downloading bor binary package for $system from '$url' to '$tmpDir'..."
+fetch "$url" "$package" || oops "failed to download '$url'"
+
+if [ $type = "tar.gz" ]; then
+    require_util tar "unpack the binary package"
+    unpack=$tmpDir/unpack
+    mkdir -p "$unpack"
+    tar -xzf "$package" -C "$unpack" || oops "failed to unpack '$package'"
+    sudo cp "${unpack}/bor" /usr/local/bin/bor || oops "failed to copy bor binary to '/usr/local/bin/bor'"
+elif [ $type = "deb" ]; then
+    echo "Installing $package ..."
+    sudo dpkg -i $package
+elif [ $type = "rpm" ]; then
+    echo "Installing $package ..."
+    sudo rpm -i --force $package
+elif [ $type = "apk" ]; then
+    echo "Installing $package ..."
+    sudo apk add --allow-untrusted $package
+fi
+
+echo "Checking bor version ..."
+bor version || oops "something went wrong"
+echo "bor has been installed successfully!"
+
+} # End of wrapping

--- a/heimdall.sh
+++ b/heimdall.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+{ # Prevent execution if this script was only partially downloaded
+
+oops() {
+    echo "$0:" "$@" >&2
+    exit 1
+}
+
+umask 0022
+
+tmpDir="$(mktemp -d -t heimdall-temp-dir-XXXXXXXXXXX || \
+          oops "Can't create temporary directory for downloading files")"
+cleanup() {
+    rm -rf "$tmpDir"
+}
+trap cleanup EXIT INT QUIT TERM
+
+require_util() {
+    command -v "$1" > /dev/null 2>&1 ||
+        oops "you do not have '$1' installed, which I need to $2"
+}
+
+version="0.2.9"
+
+if [ ! -z "$1" ]; then
+    version="$1"
+    if [ "${version:0:1}" = "v" ]; then
+        version=${version:1}
+    fi
+fi
+
+baseUrl="https://github.com/maticnetwork/heimdall/releases/download/v${version}"
+
+echo $baseUrl
+
+case "$(uname -s).$(uname -m)" in
+    Linux.x86_64)
+        if command -v dpkg &> /dev/null; then
+            type="deb"
+            binary="heimdall_${version}_linux_amd64.deb"
+        elif command -v rpm &> /dev/null; then
+            type="rpm"
+            binary="heimdall_${version}_linux_x86_64.rpm"
+        elif command -v apk &> /dev/null; then
+            type="apk"
+            binary="heimdall_${version}_linux_amd64.apk"
+        else
+            type="tar.gz"
+            binary="heimdall_${version}_linux_amd64.tar.gz"
+        fi
+        ;;
+    Linux.aarch64)
+        if command -v dpkg &> /dev/null; then
+            type="deb"
+            binary="heimdall_${version}_linux_arm64.deb"
+        elif command -v rpm &> /dev/null; then
+            type="rpm"
+            binary="heimdall_${version}_linux_arm64.rpm"
+        elif command -v apk &> /dev/null; then
+            type="apk"
+            binary="heimdall_${version}_linux_arm64.apk"
+        else
+            type="tar.gz"
+            binary="heimdall_${version}_linux_arm64.tar.gz"
+        fi
+        ;;
+    Darwin.x86_64)
+        type="tar.gz"
+        binary="heimdall_${version}_darwin_amd64.tar.gz"
+        ;;
+    Darwin.arm64|Darwin.aarch64)
+        type="tar.gz"
+        binary="heimdall_${version}_darwin_arm64.tar.gz"
+        ;;
+    *) oops "sorry, there is no binary distribution for your platform";;
+esac
+
+url="${baseUrl}/${binary}"
+
+package=$tmpDir/$binary
+
+if command -v curl > /dev/null 2>&1; then
+    fetch() { curl -L "$1" -o "$2"; }
+elif command -v wget > /dev/null 2>&1; then
+    fetch() { wget "$1" -O "$2"; }
+else
+    oops "you don't have wget or curl installed, which I need to download the binary package"
+fi
+
+echo "downloading heimdall binary package for $system from '$url' to '$tmpDir'..."
+fetch "$url" "$package" || oops "failed to download '$url'"
+
+if [ $type = "tar.gz" ]; then
+    require_util tar "unpack the binary package"
+    unpack=$tmpDir/unpack
+    mkdir -p "$unpack"
+    tar -xzf "$package" -C "$unpack" || oops "failed to unpack '$package'"
+    sudo cp "${unpack}/heimdalld" /usr/local/bin/heimdalld || oops "failed to copy heimdalld binary to '/usr/local/bin/heimdalld'"
+    sudo cp "${unpack}/heimdallcli" /usr/local/bin/heimdallcli || oops "failed to copy heimdallcli binary to '/usr/local/bin/heimdallcli'"
+    sudo cp "${unpack}/bridge" /usr/local/bin/bridge || oops "failed to copy bridge binary to '/usr/local/bin/bridge'"
+elif [ $type = "deb" ]; then
+    echo "Installing $package ..."
+    sudo dpkg -i $package
+elif [ $type = "rpm" ]; then
+    echo "Installing $package ..."
+    sudo rpm -i --force $package
+elif [ $type = "apk" ]; then
+    echo "Installing $package ..."
+    sudo apk add --allow-untrusted $package
+fi
+
+echo "Checking heimdalld version ..."
+heimdalld version || oops "something went wrong"
+echo "Checking heimdallcli version ..."
+heimdallcli version || oops "something went wrong"
+echo "Checking bridge version ..."
+bridge version || oops "something went wrong"
+echo "heimdall has been installed successfully!"
+
+} # End of wrapping


### PR DESCRIPTION
Add scripts to install bor and heimdall based on OS distribution and architecture.

Sample test output:

```
Run ./bor.sh
https://github.com/maticnetwork/bor/releases/download/v0.2.14
downloading bor binary package for  from 'https://github.com/maticnetwork/bor/releases/download/v0.2.14/bor_0.2.14_linux_amd64.deb' to '/tmp/bor-temp-dir-ZSuSCEeMilz'...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   665  100   665    0     0   2995      0 --:--:-- --:--:-- --:--:--  2995

 58 12.0M   58 [7](https://github.com/maticnetwork/install/runs/6070588545?check_suite_focus=true#step:3:7)225k    0     0  12.8M      0 --:--:-- --:--:-- --:--:-- 12.8M
100 12.0M  100 12.0M    0     0  17.2M      0 --:--:-- --:--:-- --:--:-- 33.5M
Installing /tmp/bor-temp-dir-ZSuSCEeMilz/bor_0.2.14_linux_amd64.deb ...
Selecting previously unselected package bor.
(Reading database ... 242701 files and directories currently installed.)
Preparing to unpack .../bor_0.2.14_linux_amd64.deb ...
Unpacking bor (0.2.14) ...
Setting up bor (0.2.14) ...
Checking bor version ...
Bor
Version: 0.2.14-stable
Architecture: amd64
Go Version: go1.17.2
Operating System: linux
GOPATH=
GOROOT=/usr/local/go
bor has been installed successfully!
https://github.com/maticnetwork/bor/releases/download/v0.2.14
downloading bor binary package for  from 'https://github.com/maticnetwork/bor/releases/download/v0.2.14/bor_0.2.14_linux_amd64.deb' to '/tmp/bor-temp-dir-o7aTw21m7Qc'...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   665  100   665    0     0   5277      0 --:--:-- --:--:-- --:--:--  5277

100 12.0M  100 12.0M    0     0  35.[8](https://github.com/maticnetwork/install/runs/6070588545?check_suite_focus=true#step:3:8)M      0 --:--:-- --:--:-- --:--:-- 35.8M
Installing /tmp/bor-temp-dir-o7aTw21m7Qc/bor_0.2.14_linux_amd64.deb ...
(Reading database ... 242704 files and directories currently installed.)
Preparing to unpack .../bor_0.2.14_linux_amd64.deb ...
Unpacking bor (0.2.14) over (0.2.14) ...
Setting up bor (0.2.14) ...
Checking bor version ...
Bor
Version: 0.2.14-stable
Architecture: amd64
Go Version: go1.17.2
Operating System: linux
GOPATH=
GOROOT=/usr/local/go
bor has been installed successfully!
https://github.com/maticnetwork/heimdall/releases/download/v0.2.[9](https://github.com/maticnetwork/install/runs/6070588545?check_suite_focus=true#step:3:9)
downloading heimdall binary package for  from 'https://github.com/maticnetwork/heimdall/releases/download/v0.2.9/heimdall_0.2.9_linux_amd64.deb' to '/tmp/heimdall-temp-dir-RG1Cp1SsjA2'...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
[10](https://github.com/maticnetwork/install/runs/6070588545?check_suite_focus=true#step:3:10)0   669  100   669    0     0   3577      0 --:--:-- --:--:-- --:--:--  3558

 85 56.3M   85 48.0M    0     0  41.1M      0  0:00:01  0:00:01 --:--:-- 41.1M
100 56.3M  100 56.3M    0     0  43.2M      0  0:00:01  0:00:01 --:--:-- 62.6M
Installing /tmp/heimdall-temp-dir-RG1Cp1SsjA2/heimdall_0.2.9_linux_amd64.deb ...
Selecting previously unselected package heimdall.
(Reading database ... 242704 files and directories currently installed.)
Preparing to unpack .../heimdall_0.2.9_linux_amd64.deb ...
Unpacking heimdall (0.2.9) ...
Setting up heimdall (0.2.9) ...
Checking heimdalld version ...
0.2.9
Checking heimdallcli version ...
0.2.9
Checking bridge version ...
0.2.9
heimdall has been installed successfully!
https://github.com/maticnetwork/heimdall/releases/download/v0.2.9
downloading heimdall binary package for  from 'https://github.com/maticnetwork/heimdall/releases/download/v0.2.9/heimdall_0.2.9_linux_amd64.deb' to '/tmp/heimdall-temp-dir-HFaWSETqMJK'...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   669  100   669    0     0   5226      0 --:--:-- --:--:-- --:--:--  5226

 82 56.3M   82 46.3M    0     0  79.1M      0 --:--:-- --:--:-- --:--:-- 79.1M
100 56.3M  100 56.3M    0     0  89.3M      0 --:--:-- --:--:-- --:--:--  226M
Installing /tmp/heimdall-temp-dir-HFaWSETqMJK/heimdall_0.2.9_linux_amd64.deb ...
(Reading database ... 2427[13](https://github.com/maticnetwork/install/runs/6070588545?check_suite_focus=true#step:3:13) files and directories currently installed.)
Preparing to unpack .../heimdall_0.2.9_linux_amd[64](https://github.com/maticnetwork/install/runs/6070588545?check_suite_focus=true#step:3:64).deb ...
Unpacking heimdall (0.2.9) over (0.2.9) ...
Setting up heimdall (0.2.9) ...
Checking heimdalld version ...
0.2.9
Checking heimdallcli version ...
0.2.9
Checking bridge version ...
0.2.9
heimdall has been installed successfully!
```