### PR TITLE
Bump bor version to 0.2.14-tmp-span-hotfix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
           run: |
             bash /artifacts/bor.sh
-            bash /artifacts/bor.sh 0.2.14
+            bash /artifacts/bor.sh 0.2.14-tmp-span-hotfix
             bash /artifacts/heimdall.sh
             bash /artifacts/heimdall.sh 0.2.9
 
@@ -67,6 +67,6 @@ jobs:
       - name: Install binary
         run: |
           ./bor.sh
-          ./bor.sh 0.2.14
+          ./bor.sh 0.2.14-tmp-span-hotfix
           ./heimdall.sh
           ./heimdall.sh 0.2.9

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cd install
 Simply pass the version tag as the first argument to the installation script. Notice that the script will overwrite existing bor binaries if they exist. Example:
 
 ```
-./bor.sh 0.2.14
+./bor.sh 0.2.14-tmp-span-hotfix
 ```
 
 

--- a/bor.sh
+++ b/bor.sh
@@ -21,7 +21,7 @@ require_util() {
         oops "you do not have '$1' installed, which I need to $2"
 }
 
-version="0.2.14"
+version="0.2.14-tmp-span-hotfix"
 
 if [ ! -z "$1" ]; then
     version="$1"


### PR DESCRIPTION
Bump bor version to 0.2.14-tmp-span-hotfix, because 0.2.14 shouldn't be used (we also deleted its binaries from release page as well). 