### PR TITLE
Remove previous binary before installing new versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install binary
         run: |
-          ./bor.sh
           ./bor.sh 0.2.17
-          ./heimdall.sh
           ./heimdall.sh 0.2.11

--- a/bor.sh
+++ b/bor.sh
@@ -22,7 +22,7 @@ require_util() {
         oops "you do not have '$1' installed, which I need to $2"
 }
 
-version="0.2.17"
+version="0.3.0"
 network="mainnet"
 nodetype="sentry"
 
@@ -197,15 +197,19 @@ if [ $type = "tar.gz" ]; then
     tar -xzf "$package" -C "$unpack" || oops "failed to unpack '$package'"
     sudo cp "${unpack}/bor" /usr/local/bin/bor || oops "failed to copy bor binary to '/usr/local/bin/bor'"
 elif [ $type = "deb" ]; then
+    echo "Uninstalling any existing old binary ..."
+    sudo dpkg -r bor
     echo "Installing $package ..."
     sudo dpkg -i $package
-    if [ ! -z "$profilePackage" ]; then
+    if [ ! -z "$profilePackage" ] && [ ! -f /var/lib/bor/config.toml ]; then
         sudo dpkg -i $profilePackage
     fi
 elif [ $type = "rpm" ]; then
+    echo "Uninstalling any existing old binary ..."
+    sudo rpm -e bor
     echo "Installing $package ..."
     sudo rpm -i --force $package
-    if [ ! -z "$profilePackage" ]; then
+    if [ ! -z "$profilePackage" ] && [ ! -f /var/lib/bor/config.toml ]; then
         sudo rpm -i --force $profilePackage
     fi
 elif [ $type = "apk" ]; then

--- a/heimdall.sh
+++ b/heimdall.sh
@@ -22,7 +22,7 @@ require_util() {
         oops "you do not have '$1' installed, which I need to $2"
 }
 
-version="0.2.11"
+version="0.3.0"
 newCLIVersion="0.3.0"
 network="mainnet"
 nodetype="sentry"
@@ -202,15 +202,19 @@ if [ $type = "tar.gz" ]; then
         sudo cp "${unpack}/bridge" /usr/local/bin/bridge || oops "failed to copy bridge binary to '/usr/local/bin/bridge'"
     fi
 elif [ $type = "deb" ]; then
+    echo "Uninstalling any existing old binary ..."
+    sudo dpkg -r heimdall
     echo "Installing $package ..."
     sudo dpkg -i $package
-    if [ ! -z "$profilePackage" ]; then
+    if [ ! -z "$profilePackage" ] && [ ! -d /var/lib/heimdall/config ]; then
         sudo dpkg -i $profilePackage
     fi
 elif [ $type = "rpm" ]; then
+    echo "Uninstalling any existing old binary ..."
+    sudo rpm -e heimdall
     echo "Installing $package ..."
     sudo rpm -i --force $package
-    if [ ! -z "$profilePackage" ]; then
+    if [ ! -z "$profilePackage" ] && [ ! -d /var/lib/heimdall/config ]; then
         sudo rpm -i --force $profilePackage
     fi
 elif [ $type = "apk" ]; then


### PR DESCRIPTION
This commit addresses two issues:

1. Remove any existing bor/heimdall binary if they already exist on the machine before installation.
2. Don't install profile packages if package config already present on the machine.