### PR TITLE
Handle archive node type in heimdall install script

### DIFF
--- a/heimdall.sh
+++ b/heimdall.sh
@@ -69,6 +69,8 @@ fi
 if [ ! -z "$3" ]; then
     if [ "$3" = "sentry" ] || [ "$3" = "validator" ]; then
         nodetype="$3"
+    elif [ "$3" = "archive" ]; then
+        echo "No option of archive node type in heimdall. Using default mode: $nodetype"
     else
         echo "Invalid node type: $3, choose from 'sentry' or 'validator'"
         exit 1


### PR DESCRIPTION
This PR accepts `archive` mode as a node type in heimdall installation. As there's no such type for heimdall, it will use the default type which is `sentry`. The motivation behind this change is to have as much less variables as possible in bor and heimdall installation. 