### PR TITLE
use absolute path for printing version in bor and heimdall

### DIFF
--- a/bor.sh
+++ b/bor.sh
@@ -218,7 +218,7 @@ elif [ $type = "apk" ]; then
 fi
 
 echo "Checking bor version ..."
-bor version || oops "something went wrong"
+/usr/bin/bor version || oops "something went wrong"
 echo "bor has been installed successfully!"
 
 } # End of wrapping

--- a/heimdall.sh
+++ b/heimdall.sh
@@ -229,7 +229,7 @@ if [ "$version" \< "$newCLIVersion" ]; then
     bridge version || oops "something went wrong"
 fi
 echo "Checking heimdalld version ..."
-heimdalld version || oops "something went wrong"
+/usr/bin/heimdalld version || oops "something went wrong"
 
 echo "heimdall has been installed successfully!"
 


### PR DESCRIPTION
Use `/usr/bin/bor` and `/usr/bin/heimdalld` for printing version. 