### PR TITLE
Check existence of config files with privileged permission

### DIFF
--- a/bor.sh
+++ b/bor.sh
@@ -201,7 +201,7 @@ elif [ $type = "deb" ]; then
     sudo dpkg -r bor
     echo "Installing $package ..."
     sudo dpkg -i $package
-    if [ ! -z "$profilePackage" ] && [ ! -f /var/lib/bor/config.toml ]; then
+    if [ ! -z "$profilePackage" ] && sudo [ ! -f /var/lib/bor/config.toml ]; then
         sudo dpkg -i $profilePackage
     fi
 elif [ $type = "rpm" ]; then
@@ -209,7 +209,7 @@ elif [ $type = "rpm" ]; then
     sudo rpm -e bor
     echo "Installing $package ..."
     sudo rpm -i --force $package
-    if [ ! -z "$profilePackage" ] && [ ! -f /var/lib/bor/config.toml ]; then
+    if [ ! -z "$profilePackage" ] && sudo [ ! -f /var/lib/bor/config.toml ]; then
         sudo rpm -i --force $profilePackage
     fi
 elif [ $type = "apk" ]; then

--- a/heimdall.sh
+++ b/heimdall.sh
@@ -208,7 +208,7 @@ elif [ $type = "deb" ]; then
     sudo dpkg -r heimdalld
     echo "Installing $package ..."
     sudo dpkg -i $package
-    if [ ! -z "$profilePackage" ] && [ ! -d /var/lib/heimdall/config ]; then
+    if [ ! -z "$profilePackage" ] && sudo [ ! -d /var/lib/heimdall/config ]; then
         sudo dpkg -i $profilePackage
     fi
 elif [ $type = "rpm" ]; then
@@ -216,7 +216,7 @@ elif [ $type = "rpm" ]; then
     sudo rpm -e heimdall
     echo "Installing $package ..."
     sudo rpm -i --force $package
-    if [ ! -z "$profilePackage" ] && [ ! -d /var/lib/heimdall/config ]; then
+    if [ ! -z "$profilePackage" ] && sudo [ ! -d /var/lib/heimdall/config ]; then
         sudo rpm -i --force $profilePackage
     fi
 elif [ $type = "apk" ]; then


### PR DESCRIPTION
Sometimes the current user doesn't have permission to verify if the config dir already exists. This can result in config being overwritten. This change will use sudo permission to make sure the existence of a config directory is correctly verified.