### PR TITLE
Adding bootnode to the conditionals for install scripts to prevent fa…

### DIFF
--- a/bor.sh
+++ b/bor.sh
@@ -66,10 +66,10 @@ if [ ! -z "$2" ]; then
 fi
 
 if [ ! -z "$3" ]; then
-    if [ "$3" = "sentry" ] || [ "$3" = "validator" ] || [ "$3" = "archive" ]; then
+    if [ "$3" = "sentry" ] || [ "$3" = "validator" ] || [ "$3" = "archive" ] || [ "$3" = "bootnode" ]; then
         nodetype="$3"
     else
-        echo "Invalid node type: $3, choose from 'sentry', 'validator' or 'archive'"
+        echo "Invalid node type: $3, choose from 'sentry', 'validator', 'archive',  or 'bootnode'"
         exit 1
     fi
 fi

--- a/heimdall.sh
+++ b/heimdall.sh
@@ -71,6 +71,8 @@ if [ ! -z "$3" ]; then
         nodetype="$3"
     elif [ "$3" = "archive" ]; then
         echo "No option of archive node type in heimdall. Using default mode: $nodetype"
+    elif [ "$3" = "bootnode" ]; then
+        echo "No option of bootnode type in heimdall. Using default mode: $nodetype"
     else
         echo "Invalid node type: $3, choose from 'sentry' or 'validator'"
         exit 1


### PR DESCRIPTION
Adding bootnode to the conditionals in the install scripts for bor and heimdall. Heimdall does not have a bootnode and will default to the sentry. Bor has this option and the package is available for use now. 