### PR TITLE
Bumping version numbers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             --volume "${PWD}:/artifacts"
 
           run: |
-            bash /artifacts/bor.sh v1.5.0 amoy sentry
+            bash /artifacts/bor.sh v1.5.3 amoy sentry
             bash /artifacts/heimdall.sh v1.0.10 amoy sentry
 
   install_amd64:
@@ -56,5 +56,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install binary
         run: |
-          ./bor.sh v1.5.0 amoy sentry
+          ./bor.sh v1.5.3 amoy sentry
           ./heimdall.sh v1.0.10 amoy sentry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             --volume "${PWD}:/artifacts"
 
           run: |
-            bash /artifacts/bor.sh v1.4.0 amoy sentry
+            bash /artifacts/bor.sh v1.5.0 amoy sentry
             bash /artifacts/heimdall.sh v1.0.10 amoy sentry
 
   install_amd64:
@@ -56,5 +56,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install binary
         run: |
-          ./bor.sh v1.4.0 amoy sentry
+          ./bor.sh v1.5.0 amoy sentry
           ./heimdall.sh v1.0.10 amoy sentry

--- a/bor.sh
+++ b/bor.sh
@@ -22,7 +22,7 @@ require_util() {
         oops "you do not have '$1' installed, which I need to $2"
 }
 
-version="0.3.0"
+version="1.5.0"
 network="mainnet"
 nodetype="sentry"
 

--- a/bor.sh
+++ b/bor.sh
@@ -22,7 +22,7 @@ require_util() {
         oops "you do not have '$1' installed, which I need to $2"
 }
 
-version="1.5.0"
+version="1.5.3"
 network="mainnet"
 nodetype="sentry"
 


### PR DESCRIPTION
Bumping bor version as default

Bumping bor version used in ci.yml, 1.5.0 uses the all and noarch for naming of profiles. 