### PR TITLE
Adding steps for handling removal/reinstall of packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,15 +40,13 @@ jobs:
           # Mount the root directory as /artifacts in the container
           dockerRunArgs: |
             --volume "${PWD}:/artifacts"
-          # Existing version
           run: |
+            # Existing Version
             bash /artifacts/bor.sh v1.5.4 amoy sentry
             bash /artifacts/heimdall.sh v1.2.0 amoy sentry
-          # New Version
-      - name: new version test of install/removal (arm64/aarch64)
-        run: |
-          bash /artifacts/bor.sh v1.5.4 amoy sentry
-          bash /artifacts/heimdall.sh v1.2.0 amoy sentry
+            # New Version
+            bash /artifacts/bor.sh v1.5.4 amoy sentry
+            bash /artifacts/heimdall.sh v1.2.0 amoy sentry
 
   install_amd64:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2
-        name: Install binary
+        name: Install binary (arm64/aarch64 install)
         with:
           arch: ${{ matrix.arch }}
           distro: ${{ matrix.distro }}
@@ -40,10 +40,15 @@ jobs:
           # Mount the root directory as /artifacts in the container
           dockerRunArgs: |
             --volume "${PWD}:/artifacts"
-
+          # Existing version
           run: |
             bash /artifacts/bor.sh v1.5.4 amoy sentry
             bash /artifacts/heimdall.sh v1.2.0 amoy sentry
+          # New Version
+      - name: new version test of install/removal (arm64/aarch64)
+        run: |
+          bash /artifacts/bor.sh v1.5.4 amoy sentry
+          bash /artifacts/heimdall.sh v1.2.0 amoy sentry
 
   install_amd64:
     runs-on: ${{ matrix.os }}
@@ -54,7 +59,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install binary
+      - name: Install binary(amd64/x86)
+        run: |
+          ./bor.sh v1.5.4 amoy sentry
+          ./heimdall.sh v1.2.0 amoy sentry
+
+      - name: Install binary and test removal(amd64/x86)
         run: |
           ./bor.sh v1.5.4 amoy sentry
           ./heimdall.sh v1.2.0 amoy sentry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        # Existing version
       - name: Install binary(amd64/x86)
         run: |
           ./bor.sh v1.5.4 amoy sentry
           ./heimdall.sh v1.2.0 amoy sentry
-
+        # New version
       - name: Install binary and test removal(amd64/x86)
         run: |
           ./bor.sh v1.5.4 amoy sentry


### PR DESCRIPTION
Adding additional steps for each of the architectures. This allows for the testing of removal and installs on each of the platform.

Going forward, one would remain the "old" version that would be the baseline, the second install step would be for the "new" version in order to test all packaging processes.